### PR TITLE
Explicit annotated constructor instead of @AllArgsConstructor annotation for @Builder

### DIFF
--- a/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
@@ -1,19 +1,17 @@
 package net.smartcosmos.dto.objects;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
+import java.beans.ConstructorProperties;
 
 /**
  * @author voor
  */
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-@AllArgsConstructor
-@Builder
 public class ObjectCreate {
     @NotNull
     private String objectUrn;
@@ -22,6 +20,18 @@ public class ObjectCreate {
     @NotNull
     private String name;
     private String description;
-    private Boolean activeFlag = true;
+    private Boolean activeFlag;
     private String moniker;
+
+    @Builder
+    @ConstructorProperties({"objectUrn", "type", "name", "description", "activeFlag", "moniker"})
+    public ObjectCreate(String objectUrn, String type, String name, String description, Boolean activeFlag, String moniker)
+    {
+        this.objectUrn = objectUrn;
+        this.type = type;
+        this.name = name;
+        this.description = description;
+        this.activeFlag = activeFlag != null ? activeFlag : true;
+        this.moniker = moniker;
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
@@ -19,6 +19,6 @@ public class ObjectUpdate {
     @NotNull
     private String name;
     private String description;
-    private Boolean activeFlag = true;
+    private Boolean activeFlag;
     private String moniker;
 }


### PR DESCRIPTION
Lombok's `@Builder` is not able to deal with field initialization default values. That's a known issue which won't get fixed: https://github.com/rzwitserloot/lombok/issues/663

We therefore provide our own AllArgsConstructor that is used by the generated builder and takes care of field initialization.
