### PR TITLE
Feature/not empty annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>

--- a/src/main/java/net/smartcosmos/dto/annotation/NotEmpty.java
+++ b/src/main/java/net/smartcosmos/dto/annotation/NotEmpty.java
@@ -1,0 +1,35 @@
+package net.smartcosmos.dto.annotation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@NotNull
+@Size(min = 1)
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NotEmpty
+{
+    String message() default "may not be empty";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface List
+    {
+        NotEmpty[] value();
+    }
+}

--- a/src/main/java/net/smartcosmos/dto/annotation/NotEmpty.java
+++ b/src/main/java/net/smartcosmos/dto/annotation/NotEmpty.java
@@ -2,17 +2,15 @@ package net.smartcosmos.dto.annotation;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 
 @NotNull
 @Size(min = 1)
+@ReportAsSingleViolation
 @Documented
 @Constraint(validatedBy = {})
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.ANNOTATION_TYPE})

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
@@ -3,8 +3,8 @@ package net.smartcosmos.dto.objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
 import lombok.Data;
+import net.smartcosmos.dto.annotation.NotEmpty;
 
-import javax.validation.constraints.NotNull;
 import java.beans.ConstructorProperties;
 
 /**
@@ -13,11 +13,11 @@ import java.beans.ConstructorProperties;
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ObjectCreate {
-    @NotNull
+    @NotEmpty
     private String objectUrn;
-    @NotNull
+    @NotEmpty
     private String type;
-    @NotNull
+    @NotEmpty
     private String name;
     private String description;
     private Boolean activeFlag;

--- a/src/test/java/net/smartcosmos/dto/objects/ObjectCreateTest.java
+++ b/src/test/java/net/smartcosmos/dto/objects/ObjectCreateTest.java
@@ -1,18 +1,68 @@
 package net.smartcosmos.dto.objects;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Basic Unit Tests for the ObjectCreate object...
  */
+@SuppressWarnings("Duplicates")
 public class ObjectCreateTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
     @Test
     public void thatObjectCreateAlwaysHasActiveFlag() throws Exception {
         ObjectCreate objectCreate = ObjectCreate.builder().objectUrn("objectUrn").type("type").name("name").build();
 
         assertTrue(objectCreate.getActiveFlag());
+    }
+
+    @Test
+    public void thatObjectCreateMustHaveObjectURN() {
+
+        ObjectCreate objectCreate = ObjectCreate.builder()
+            .type("type")
+            .name("name").build();
+
+        Set<ConstraintViolation<ObjectCreate>> constraintViolations = validator.validate(objectCreate);
+
+        assertFalse(constraintViolations.isEmpty());
+
+        assertEquals(1, constraintViolations.size() );
+        assertEquals("may not be empty", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void thatObjectCreateMustHaveEmptyObjectURN() {
+
+        ObjectCreate objectCreate = ObjectCreate.builder()
+            .objectUrn("")
+            .type("type")
+            .name("name").build();
+
+        Set<ConstraintViolation<ObjectCreate>> constraintViolations = validator.validate(objectCreate);
+
+        assertFalse(constraintViolations.isEmpty());
+
+        assertEquals(1, constraintViolations.size() );
+        assertEquals("may not be empty", constraintViolations.iterator().next().getMessage());
     }
 
 }

--- a/src/test/java/net/smartcosmos/dto/objects/ObjectCreateTest.java
+++ b/src/test/java/net/smartcosmos/dto/objects/ObjectCreateTest.java
@@ -50,7 +50,7 @@ public class ObjectCreateTest {
     }
 
     @Test
-    public void thatObjectCreateMustHaveEmptyObjectURN() {
+    public void thatObjectCreateMustNotHaveEmptyObjectURN() {
 
         ObjectCreate objectCreate = ObjectCreate.builder()
             .objectUrn("")


### PR DESCRIPTION
### What changes were proposed in this pull request?

The previously used `@NotNull` annotation is replaced by a custom `NotEmpty` annotation. It would have been possible to use the corresponding Hibernate annotation, but that required pulling in the complete `hibernate-validator` dependency which is not appropriate for a constraint that just combines `@NotNull` and `@Size(min = 1)`.
### How is this patch documented?

The code should speak for itself. :sunglasses:
### How was this patch tested?

There are two unit tests in `ObjectsCreateTest` that test if the custom constraint annotation catches null or empty values.
#### Depends On

Nothing else.
