### PR TITLE
Feature/update objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,27 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.el</groupId>
+            <artifactId>javax.el-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.el</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.web</groupId>
-            <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,20 +43,15 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  */
 public interface IObjectDao {
 
-    ObjectResponse create(String accountUrn, ObjectCreate objectCreate);
+    ObjectResponse create(String accountUrn, ObjectCreate objectCreate) throws ConstraintViolationException;
 
     Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate) throws ConstraintViolationException;
 

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -1,10 +1,11 @@
 package net.smartcosmos.dao.objects;
 
-import java.util.List;
-import java.util.Optional;
-
 import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
+import net.smartcosmos.dto.objects.ObjectUpdate;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * @author voor
@@ -13,7 +14,7 @@ public interface IObjectDao {
 
     ObjectResponse create(String accountUrn, ObjectCreate objectCreate);
 
-    Optional<ObjectResponse> update(String accountUrn, ObjectResponse objectUpdate);
+    Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate);
 
     Optional<ObjectResponse> findByObjectUrn(String accountUrn, String objectUrn);
 

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -15,7 +15,7 @@ public interface IObjectDao {
 
     ObjectResponse create(String accountUrn, ObjectCreate objectCreate);
 
-    Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate);
+    Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate) throws IllegalArgumentException;
 
     Optional<ObjectResponse> findByObjectUrn(String accountUrn, String objectUrn);
 

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -4,6 +4,7 @@ import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
 
+import javax.validation.Valid;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -15,7 +16,7 @@ public interface IObjectDao {
 
     ObjectResponse create(String accountUrn, ObjectCreate objectCreate);
 
-    Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate) throws IllegalArgumentException;
+    Optional<ObjectResponse> update(String accountUrn, @Valid ObjectUpdate objectUpdate) throws IllegalArgumentException;
 
     Optional<ObjectResponse> findByObjectUrn(String accountUrn, String objectUrn);
 

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -1,12 +1,8 @@
 package net.smartcosmos.dao.objects;
 
 import net.smartcosmos.dto.objects.ObjectCreate;
-import net.smartcosmos.dto.objects.ObjectUpdate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
-
-import java.util.List;
-import java.util.Optional;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -4,7 +4,7 @@ import net.smartcosmos.dto.objects.ObjectCreate;
 import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
 
-import javax.validation.Valid;
+import javax.validation.ConstraintViolationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -16,7 +16,7 @@ public interface IObjectDao {
 
     ObjectResponse create(String accountUrn, ObjectCreate objectCreate);
 
-    Optional<ObjectResponse> update(String accountUrn, @Valid ObjectUpdate objectUpdate) throws IllegalArgumentException;
+    Optional<ObjectResponse> update(String accountUrn, ObjectUpdate objectUpdate) throws ConstraintViolationException;
 
     Optional<ObjectResponse> findByObjectUrn(String accountUrn, String objectUrn);
 

--- a/src/main/java/net/smartcosmos/dto/annotation/SmartCosmosIdDefined.java
+++ b/src/main/java/net/smartcosmos/dto/annotation/SmartCosmosIdDefined.java
@@ -1,0 +1,28 @@
+package net.smartcosmos.dto.annotation;
+
+import net.smartcosmos.dto.objects.validation.ObjectsUpdateIdValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A constraint annotation to check if an identifier is appropriately specified, like objectUrn or urn.
+ */
+@Documented
+@Target({ANNOTATION_TYPE, TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = { ObjectsUpdateIdValidator.class} )
+public @interface SmartCosmosIdDefined {
+    String message() default "URN and Object URN may not be null, and only one of them may be defined";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import net.smartcosmos.dto.annotation.SmartCosmosIdDefined;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
 @Builder
+@SmartCosmosIdDefined
 public class ObjectUpdate {
     private String objectUrn;
     private String urn;

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
@@ -1,0 +1,20 @@
+package net.smartcosmos.dto.objects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+@AllArgsConstructor
+@Builder
+public class ObjectUpdate {
+    private String objectUrn;
+    private String urn;
+    private String type;
+    private String name;
+    private String description;
+    private Boolean activeFlag;
+    private String moniker;
+}

--- a/src/main/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidator.java
+++ b/src/main/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidator.java
@@ -1,0 +1,37 @@
+package net.smartcosmos.dto.objects.validation;
+
+import net.smartcosmos.dto.annotation.SmartCosmosIdDefined;
+import net.smartcosmos.dto.objects.ObjectUpdate;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Checks that either {@code objectUrn} or {@code urn} are defined (not {@code null}) for an {@link ObjectUpdate}.
+ */
+public class ObjectsUpdateIdValidator implements ConstraintValidator<SmartCosmosIdDefined, ObjectUpdate> {
+    @Override
+    public void initialize(SmartCosmosIdDefined smartCosmosIdDefined) {
+
+    }
+
+    @Override
+    public boolean isValid(ObjectUpdate objectUpdate, ConstraintValidatorContext constraintValidatorContext) {
+
+        // We want to override the default constraint violation message, and if we didn't disable the default violation,
+        // we would end up with multiple violations.
+        constraintValidatorContext.disableDefaultConstraintViolation();
+
+        if (objectUpdate.getUrn() == null && objectUpdate.getObjectUrn() == null) {
+            constraintValidatorContext.buildConstraintViolationWithTemplate("URN and Object URN may not be null").addConstraintViolation();
+            return false;
+        }
+
+        if (objectUpdate.getUrn() != null && objectUpdate.getObjectUrn() != null) {
+            constraintValidatorContext.buildConstraintViolationWithTemplate("either URN or Object URN may be defined").addConstraintViolation();
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidator.java
+++ b/src/main/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidator.java
@@ -22,7 +22,7 @@ public class ObjectsUpdateIdValidator implements ConstraintValidator<SmartCosmos
         // we would end up with multiple violations.
         constraintValidatorContext.disableDefaultConstraintViolation();
 
-        if (objectUpdate.getUrn() == null && objectUpdate.getObjectUrn() == null) {
+        if (isNullOrEmpty(objectUpdate.getUrn()) && isNullOrEmpty(objectUpdate.getObjectUrn())) {
             constraintValidatorContext.buildConstraintViolationWithTemplate("URN and Object URN may not be null").addConstraintViolation();
             return false;
         }
@@ -33,5 +33,9 @@ public class ObjectsUpdateIdValidator implements ConstraintValidator<SmartCosmos
         }
 
         return true;
+    }
+
+    private boolean isNullOrEmpty(String text) {
+        return text == null || text.isEmpty();
     }
 }

--- a/src/test/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidationTest.java
+++ b/src/test/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidationTest.java
@@ -25,7 +25,7 @@ public class ObjectsUpdateIdValidationTest {
     }
 
     @Test
-    public void validUrn() {
+    public void thatValidationPassesIfURNSet() {
 
         ObjectUpdate update = ObjectUpdate.builder()
             .urn("urn:uuid:MY-TEST-URN")
@@ -38,7 +38,7 @@ public class ObjectsUpdateIdValidationTest {
     }
 
     @Test
-    public void validObjectUrn() {
+    public void thatValidationPassesIfObjectURNSet() {
 
         ObjectUpdate update = ObjectUpdate.builder()
             .objectUrn("urn:MY-TEST-OBJECT-URN")
@@ -51,7 +51,7 @@ public class ObjectsUpdateIdValidationTest {
     }
 
     @Test
-    public void invalid() {
+    public void thatMissingURNOrObjectURNFailsValidation() {
         ObjectUpdate update = ObjectUpdate.builder()
             .build();
 
@@ -64,7 +64,7 @@ public class ObjectsUpdateIdValidationTest {
     }
 
     @Test
-    public void overspecified() {
+    public void thatSettingBothURNAndObjectURNFailsValidation() {
         ObjectUpdate update = ObjectUpdate.builder()
             .urn("urn:uuid:MY-TEST-URN")
             .objectUrn("urn:MY-TEST-OBJECT-URN")
@@ -76,5 +76,51 @@ public class ObjectsUpdateIdValidationTest {
         assertFalse(constraintViolations.isEmpty());
         assertEquals( 1, constraintViolations.size() );
         assertEquals("either URN or Object URN may be defined", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void thatEmptyURNFailsValidation() {
+
+        ObjectUpdate update = ObjectUpdate.builder()
+            .urn("")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertFalse(constraintViolations.isEmpty());
+        assertEquals( 1, constraintViolations.size() );
+        assertEquals("URN and Object URN may not be null", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void thatEmptyObjectURNFailsValidation() {
+
+        ObjectUpdate update = ObjectUpdate.builder()
+            .objectUrn("")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertFalse(constraintViolations.isEmpty());
+        assertEquals( 1, constraintViolations.size() );
+        assertEquals("URN and Object URN may not be null", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void thatEmptyURNAndObjectURNFailsValidation() {
+
+        ObjectUpdate update = ObjectUpdate.builder()
+            .urn("")
+            .objectUrn("")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertFalse(constraintViolations.isEmpty());
+        assertEquals( 1, constraintViolations.size() );
+        assertEquals("URN and Object URN may not be null", constraintViolations.iterator().next().getMessage());
     }
 }

--- a/src/test/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidationTest.java
+++ b/src/test/java/net/smartcosmos/dto/objects/validation/ObjectsUpdateIdValidationTest.java
@@ -1,0 +1,80 @@
+package net.smartcosmos.dto.objects.validation;
+
+import net.smartcosmos.dto.objects.ObjectUpdate;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ObjectsUpdateIdValidationTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    public void validUrn() {
+
+        ObjectUpdate update = ObjectUpdate.builder()
+            .urn("urn:uuid:MY-TEST-URN")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertTrue(constraintViolations.isEmpty());
+    }
+
+    @Test
+    public void validObjectUrn() {
+
+        ObjectUpdate update = ObjectUpdate.builder()
+            .objectUrn("urn:MY-TEST-OBJECT-URN")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertTrue(constraintViolations.isEmpty());
+    }
+
+    @Test
+    public void invalid() {
+        ObjectUpdate update = ObjectUpdate.builder()
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertFalse(constraintViolations.isEmpty());
+        assertEquals( 1, constraintViolations.size() );
+        assertEquals("URN and Object URN may not be null", constraintViolations.iterator().next().getMessage());
+    }
+
+    @Test
+    public void overspecified() {
+        ObjectUpdate update = ObjectUpdate.builder()
+            .urn("urn:uuid:MY-TEST-URN")
+            .objectUrn("urn:MY-TEST-OBJECT-URN")
+            .build();
+
+        Set<ConstraintViolation<ObjectUpdate>> constraintViolations =
+            validator.validate(update);
+
+        assertFalse(constraintViolations.isEmpty());
+        assertEquals( 1, constraintViolations.size() );
+        assertEquals("either URN or Object URN may be defined", constraintViolations.iterator().next().getMessage());
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the constraint annotations for `ObjectUpdate` that previously required `type` and `name` fields.

It also introduces a new constraint annotation `@SmartCosmosIdDefined` to make sure an update request object contains either `urn` or `objectUrn`.

Additionally, it declares `ConstraintViolationExceptions` for `create()` and `update()` which will be thrown if the DTOs or entities won't pass the validation in the persistence layer.
### How is this patch documented?

Documentation is located in code or Javadoc.
### How was this patch tested?

There are some unit tests to test the newly added annotation.
#### Depends On

Relates to `feature/updateObject` branches in RDAO and JPA, but those branches depend on the changes of this pull request.
