### PR TITLE
Feature/object update interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
@@ -66,6 +61,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/net/smartcosmos/data/constraint/NotEmpty.java
+++ b/src/main/java/net/smartcosmos/data/constraint/NotEmpty.java
@@ -1,4 +1,4 @@
-package net.smartcosmos.dto.annotation;
+package net.smartcosmos.data.constraint;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;

--- a/src/main/java/net/smartcosmos/data/objects/ObjectUpdate.java
+++ b/src/main/java/net/smartcosmos/data/objects/ObjectUpdate.java
@@ -1,0 +1,6 @@
+package net.smartcosmos.data.objects;
+
+public interface ObjectUpdate<T> {
+    T getUrn();
+    T getObjectUrn();
+}

--- a/src/main/java/net/smartcosmos/data/objects/constraint/SmartCosmosIdDefined.java
+++ b/src/main/java/net/smartcosmos/data/objects/constraint/SmartCosmosIdDefined.java
@@ -1,6 +1,6 @@
-package net.smartcosmos.dto.annotation;
+package net.smartcosmos.data.objects.constraint;
 
-import net.smartcosmos.dto.objects.validation.ObjectsUpdateIdValidator;
+import net.smartcosmos.data.objects.constraint.validation.ObjectsUpdateIdValidator;
 
 import javax.validation.Constraint;
 import javax.validation.Payload;
@@ -18,7 +18,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Documented
 @Target({ANNOTATION_TYPE, TYPE})
 @Retention(RUNTIME)
-@Constraint(validatedBy = { ObjectsUpdateIdValidator.class} )
+@Constraint(validatedBy = { ObjectsUpdateIdValidator.class } )
 public @interface SmartCosmosIdDefined {
     String message() default "URN and Object URN may not be null, and only one of them may be defined";
 

--- a/src/main/java/net/smartcosmos/data/objects/constraint/validation/ObjectsUpdateIdValidator.java
+++ b/src/main/java/net/smartcosmos/data/objects/constraint/validation/ObjectsUpdateIdValidator.java
@@ -1,7 +1,7 @@
-package net.smartcosmos.dto.objects.validation;
+package net.smartcosmos.data.objects.constraint.validation;
 
-import net.smartcosmos.dto.annotation.SmartCosmosIdDefined;
-import net.smartcosmos.dto.objects.ObjectUpdate;
+import net.smartcosmos.data.objects.ObjectUpdate;
+import net.smartcosmos.data.objects.constraint.SmartCosmosIdDefined;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -35,7 +35,10 @@ public class ObjectsUpdateIdValidator implements ConstraintValidator<SmartCosmos
         return true;
     }
 
-    private boolean isNullOrEmpty(String text) {
-        return text == null || text.isEmpty();
+    private boolean isNullOrEmpty(Object text) {
+        if (text instanceof String) {
+            return ((String) text).isEmpty();
+        }
+        return text == null;
     }
 }

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectCreate.java
@@ -3,7 +3,7 @@ package net.smartcosmos.dto.objects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Builder;
 import lombok.Data;
-import net.smartcosmos.dto.annotation.NotEmpty;
+import net.smartcosmos.data.constraint.NotEmpty;
 
 import java.beans.ConstructorProperties;
 

--- a/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/objects/ObjectUpdate.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import net.smartcosmos.dto.annotation.SmartCosmosIdDefined;
+import net.smartcosmos.data.objects.constraint.SmartCosmosIdDefined;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
 @Builder
 @SmartCosmosIdDefined
-public class ObjectUpdate {
+public class ObjectUpdate implements net.smartcosmos.data.objects.ObjectUpdate<String> {
     private String objectUrn;
     private String urn;
     private String type;

--- a/src/test/java/net/smartcosmos/data/objects/constraint/validation/ObjectsUpdateIdValidationTest.java
+++ b/src/test/java/net/smartcosmos/data/objects/constraint/validation/ObjectsUpdateIdValidationTest.java
@@ -1,4 +1,4 @@
-package net.smartcosmos.dto.objects.validation;
+package net.smartcosmos.data.objects.constraint.validation;
 
 import net.smartcosmos.dto.objects.ObjectUpdate;
 import org.junit.BeforeClass;


### PR DESCRIPTION
The package structure is changed so that the constraint annotation are not part of the `dto` package anymore. Instead, a new `data` package is introduced

This package also contains a generic interface to make sure instances or implementations of `ObjectUpdate` provide the methods required for validation. To support future (or past implementations), implementations specify the type of `urn` and `objectUrn` to allow for smoke signal support. That should eventually be two different types in order to allow different types for both fields.

Also see https://github.com/SMARTRACTECHNOLOGY/smartcosmos-ext-objects-rdao/tree/feature/object_update_interface.
