### PR TITLE
search by query params now using Specifications; next step is to move…

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/IObjectDao.java
@@ -74,25 +74,45 @@ public interface IObjectDao {
      */
     public static enum QueryParameterType {
         /**
-         * Search for Things with by urn.
+         * Search for Things by urn.
          */
         OBJECT_URN_LIKE("objectUrnLike"),
         /**
-         * Search for things by type.
+         * Actual field name.
+         */
+        OBJECT_URN_FIELD_NAME("objectUrn"),
+        /**
+         * Search for Things by type.
          */
         TYPE("type"),
         /**
-         * Search for things by name.
+         * Actual field name.
+         */
+        TYPE_FIELD_NAME("type"),
+        /**
+         * Search for Things by name.
          */
         NAME_LIKE("nameLike"),
         /**
-         * Search for things by moniker.
+         * Actual field name.
+         */
+        NAME_FIELD_NAME("name"),
+        /**
+         * Search for Things by moniker.
          */
         MONIKER_LIKE("monikerLike"),
         /**
-         * Search for things by the timestamp it was last modified.
+         * Actual field name.
          */
-        MODIFIED_AFTER("modifiedAfter");
+        MONIKER_FIELD_NAME("moniker"),
+        /**
+         * Search for Things by the timestamp it was last modified.
+         */
+        MODIFIED_AFTER("modifiedAfter"),
+        /**
+         * Actual field name.
+         */
+        MODIFIED_AFTER_FIELD_NAME("lastModified");
 
         private String parameterName;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

added  _FIELD_NAME fields to IObjectDao.QueryParameters enum for use in objects-jpa:util/SearchSpecifications
### How is this patch documented?

Just additional fields in an enum
### How was this patch tested?

The testing all happens in jpa:ObjectsPersistenceServiceTest, and they're all passing.
#### Depends On

Nothing. My next pull request in objects-jpa depends on this.
