### PR TITLE
Remove validation dependency from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,17 +63,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <scm>


### PR DESCRIPTION
Just a minor POM fix: Remove the obsolete (and duplicate) dependency for validation.
