### PR TITLE
added EXACT to QueryParameterTypes

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/ObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/ObjectDao.java
@@ -74,6 +74,10 @@ public interface ObjectDao {
      */
     public static enum QueryParameterType {
         /**
+         * Flag indicating exact String matching.
+         */
+        EXACT("exact"),
+        /**
          * Search for Things by urn.
          */
         OBJECT_URN_LIKE("objectUrnLike"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Additional EXACT field in ObjectDAO.QueryParameterType.
### How is this patch documented?

A single additional element in an enum
### How was this patch tested?

As part of the general exact flag testing in objects-jpa:ObjectPersistenceServiceTest
#### Depends On

Nothing
