### PR TITLE
POST:findByUrns implemented, which will be needed by Profiles

### DIFF
--- a/src/main/java/net/smartcosmos/dao/objects/ObjectDao.java
+++ b/src/main/java/net/smartcosmos/dao/objects/ObjectDao.java
@@ -5,6 +5,7 @@ import net.smartcosmos.dto.objects.ObjectResponse;
 import net.smartcosmos.dto.objects.ObjectUpdate;
 
 import javax.validation.ConstraintViolationException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +58,15 @@ public interface ObjectDao {
      * @return the {@link ObjectResponse} instance for the retrieved object or {@code empty} if the object does not exist
      */
     Optional<ObjectResponse> findByUrn(String accountUrn, String urn);
+
+    /**
+     * Finds all objects matching an input collection of URNs in the realm of a given account.
+     *
+     * @param accountUrn the account URN
+     * @param urns a collection of system-assigned URNs
+     * @return the {@link ObjectResponse} instance for the retrieved object or {@code empty} if the object does not exist
+     */
+    List<ObjectResponse> findByUrns(String accountUrn, Collection<String> urns);
 
     List<ObjectResponse> getObjects();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Implemented findByUrn endpoint and DAO method(s).
Takes an array of urns, and returns an array of objects. If any URN in the array does not
correspond to an objects, it returns an error method.
### How is this patch documented?

Code commentary.
### How was this patch tested?

Two additional tests in objects-rdao:GetResourceTest.java, and three additional tests in
objects-jpa:ObjectPersistenceService test.
#### Depends On

This pull request depends on nothing. The complete functionality depend on the merge of pull requests with the same name as this one into dao-objects-jpa and ext-objects-rdao.
