### PR TITLE
Add delete method signatures to ThingDao

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+smartcosmosMavenBuild {}

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -92,9 +92,9 @@ public interface ThingDao {
      *
      * @param tenantId  the tenant ID
      * @param id the thing's system-assigned ID
-     * @return the {@link ThingResponse} instance for the deleted thing or {@code empty} if the thing did not exist
+     * @return the list of deleted {@link ThingResponse} instances
      */
-    Optional<ThingResponse> deleteById(String tenantId, String id);
+    List<ThingResponse> deleteById(String tenantId, String id);
 
     /**
      * Deletes a thing matching a specified type and URN in the realm of a given tenant.
@@ -102,7 +102,7 @@ public interface ThingDao {
      * @param tenantId  the tenant ID
      * @param type the thing TYPE
      * @param urn the thing URN
-     * @return the {@link ThingResponse} instance for the deleted thing or {@code empty} if the thing did not exist
+     * @return the list of deleted {@link ThingResponse} instances
      */
-    Optional<ThingResponse> deleteByTypeAndUrn(String tenantId, String type, String urn);
+    List<ThingResponse> deleteByTypeAndUrn(String tenantId, String type, String urn);
 }

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -80,10 +80,29 @@ public interface ThingDao {
     /**
      * Return all things in the realm of a given tenant.
      *
-     * @param tenantId
+     * @param tenantId the tenant ID
      * @param page the number of the results page
      * @param size the size of a results page
      * @return
      */
     List<ThingResponse> findAll(String tenantId, Long page, Long size);
+
+    /**
+     * Deletes a thing matching a specified ID in the realm of a given tenant.
+     *
+     * @param tenantId  the tenant ID
+     * @param id the thing's system-assigned ID
+     * @return the {@link ThingResponse} instance for the deleted thing or {@code empty} if the thing did not exist
+     */
+    Optional<ThingResponse> deleteById(String tenantId, String id);
+
+    /**
+     * Deletes a thing matching a specified type and URN in the realm of a given tenant.
+     *
+     * @param tenantId  the tenant ID
+     * @param type the thing TYPE
+     * @param urn the thing URN
+     * @return the {@link ThingResponse} instance for the deleted thing or {@code empty} if the thing did not exist
+     */
+    Optional<ThingResponse> deleteByTypeAndUrn(String tenantId, String type, String urn);
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Signatures for `delete()` methods for things are added:
- by ID
- by Type and URN
### How is this patch documented?

Javadoc.
### How was this patch tested?

Tests will be in RDAO and JPA.
#### Depends On

Nothing.
