### PR TITLE
Rename tenantId to tenantUrn

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -14,37 +14,37 @@ public interface ThingDao {
     /**
      * Creates a thing in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param thingCreate the thing to create
      * @return an {@link ThingResponse} instance for the created thing
      * @throws ConstraintViolationException if the {@link ThingCreate} violates constraints enforced by the persistence service
      */
-    ThingResponse create(String tenantId, ThingCreate thingCreate) throws ConstraintViolationException;
+    ThingResponse create(String tenantUrn, ThingCreate thingCreate) throws ConstraintViolationException;
 
     /**
      * Updates a thing in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param thingUpdate the thing to update
      * @return an {@link ThingResponse} instance for the updated thing
      * @throws ConstraintViolationException if the {@link ThingUpdate} violates constraints enforced by the persistence service
      */
-    Optional<ThingResponse> update(String tenantId, ThingUpdate thingUpdate) throws ConstraintViolationException;
+    Optional<ThingResponse> update(String tenantUrn, ThingUpdate thingUpdate) throws ConstraintViolationException;
 
     /**
      * Finds a thing of TYPE matching a specified URN in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param type the thing TYPE
      * @param urn the thing URN
      * @return the {@link ThingResponse} instance for the retrieved thing or {@code empty} if the thing does not exist
      */
-    Optional<ThingResponse> findByTypeAndUrn(String tenantId, String type, String urn);
+    Optional<ThingResponse> findByTypeAndUrn(String tenantUrn, String type, String urn);
 
     /**
      * Finds things of TYPE matching a specified URN start in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param type the thing TYPE
      * @param urnStartsWith the first characters of the thing URN
      * @param page the number of the results page
@@ -52,7 +52,7 @@ public interface ThingDao {
      * @return all things whose {@code urn} starts with {@code urnStartsWith}
      */
     List<ThingResponse> findByTypeAndUrnStartsWith(
-        String tenantId,
+        String tenantUrn,
         String type,
         String urnStartsWith,
         Long page, Long size);
@@ -60,49 +60,49 @@ public interface ThingDao {
     /**
      * Finds a thing matching a specified URN in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param id the thing's system-assigned ID
      * @return the {@link ThingResponse} instance for the retrieved thing or {@code empty} if the thing does not exist
      */
-    Optional<ThingResponse> findById(String tenantId, String id);
+    Optional<ThingResponse> findById(String tenantUrn, String id);
 
     /**
      * Finds all things matching an input collection of URNs in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param ids a collection of system-assigned IDs
      * @param page the number of the results page
      * @param size the size of a results page*
      * @return a List of Optional<ThingResponse>, some of which may be empty.
      */
-    List<Optional<ThingResponse>> findByIds(String tenantId, Collection<String> ids, Long page, Long size);
+    List<Optional<ThingResponse>> findByIds(String tenantUrn, Collection<String> ids, Long page, Long size);
 
     /**
      * Return all things in the realm of a given tenant.
      *
-     * @param tenantId the tenant ID
+     * @param tenantUrn the tenant URN
      * @param page the number of the results page
      * @param size the size of a results page
      * @return
      */
-    List<ThingResponse> findAll(String tenantId, Long page, Long size);
+    List<ThingResponse> findAll(String tenantUrn, Long page, Long size);
 
     /**
      * Deletes a thing matching a specified ID in the realm of a given tenant.
      *
-     * @param tenantId  the tenant ID
+     * @param tenantUrn  the tenant URN
      * @param id the thing's system-assigned ID
      * @return the list of deleted {@link ThingResponse} instances
      */
-    List<ThingResponse> deleteById(String tenantId, String id);
+    List<ThingResponse> deleteById(String tenantUrn, String id);
 
     /**
      * Deletes a thing matching a specified type and URN in the realm of a given tenant.
      *
-     * @param tenantId  the tenant ID
+     * @param tenantUrn  the tenant URN
      * @param type the thing TYPE
      * @param urn the thing URN
      * @return the list of deleted {@link ThingResponse} instances
      */
-    List<ThingResponse> deleteByTypeAndUrn(String tenantId, String type, String urn);
+    List<ThingResponse> deleteByTypeAndUrn(String tenantUrn, String type, String urn);
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Just renames the `tenantId` parameter to `tenantUrn` to avoid UUID confusion.
### How is this patch documented?

Javadoc, Code.
### How was this patch tested?

Not here.
#### Depends On

Nothing.
