### PR TITLE
Feature/update methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
             <version>1.1.0.Final</version>
@@ -62,10 +66,6 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.swagger</groupId>
-            <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -31,7 +31,7 @@ public interface ThingDao {
      * @return an {@link ThingResponse} instance for the updated thing or {@code empty} if the thing does not exist
      * @throws ConstraintViolationException if the {@link ThingUpdate} violates constraints enforced by the persistence service
      */
-    Optional<ThingResponse> update(String tenantId, String type, String urn, ThingUpdate updateThing) throws ConstraintViolationException;
+    Optional<ThingResponse> updateByTypeAndUrn(String tenantId, String type, String urn, ThingUpdate updateThing) throws ConstraintViolationException;
 
     /**
      * Updates a thing identified by its ID in the realm of a given tenant.
@@ -42,7 +42,7 @@ public interface ThingDao {
      * @return an {@link ThingResponse} instance for the updated thing or {@code empty} if the thing does not exist
      * @throws ConstraintViolationException if the {@link ThingUpdate} violates constraints enforced by the persistence service
      */
-    Optional<ThingResponse> update(String tenantId, String id, ThingUpdate updateThing) throws ConstraintViolationException;
+    Optional<ThingResponse> updateById(String tenantId, String id, ThingUpdate updateThing) throws ConstraintViolationException;
 
     /**
      * Finds a thing of TYPE matching a specified URN in the realm of a given tenant.

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -22,14 +22,27 @@ public interface ThingDao {
     ThingResponse create(String tenantId, ThingCreate thingCreate) throws ConstraintViolationException;
 
     /**
-     * Updates a thing in the realm of a given tenant.
+     * Updates a thing identified by its type and URN in the realm of a given tenant.
      *
      * @param tenantId the tenant ID
-     * @param thingUpdate the thing to update
-     * @return an {@link ThingResponse} instance for the updated thing
+     * @param type the thing TYPE
+     * @param urn the thing URN
+     * @param updateThing the thing to update
+     * @return an {@link ThingResponse} instance for the updated thing or {@code empty} if the thing does not exist
      * @throws ConstraintViolationException if the {@link ThingUpdate} violates constraints enforced by the persistence service
      */
-    Optional<ThingResponse> update(String tenantId, ThingUpdate thingUpdate) throws ConstraintViolationException;
+    Optional<ThingResponse> update(String tenantId, String type, String urn, ThingUpdate updateThing) throws ConstraintViolationException;
+
+    /**
+     * Updates a thing identified by its ID in the realm of a given tenant.
+     *
+     * @param tenantId the tenant ID
+     * @param id the thing ID
+     * @param updateThing the thing to update
+     * @return an {@link ThingResponse} instance for the updated thing or {@code empty} if the thing does not exist
+     * @throws ConstraintViolationException if the {@link ThingUpdate} violates constraints enforced by the persistence service
+     */
+    Optional<ThingResponse> update(String tenantId, String id, ThingUpdate updateThing) throws ConstraintViolationException;
 
     /**
      * Finds a thing of TYPE matching a specified URN in the realm of a given tenant.

--- a/src/main/java/net/smartcosmos/dto/things/ThingUpdate.java
+++ b/src/main/java/net/smartcosmos/dto/things/ThingUpdate.java
@@ -16,17 +16,11 @@ public class ThingUpdate {
     @Setter(AccessLevel.NONE)
     private int version = VERSION;
 
-    private String id;
-    private String urn;
-    private String type;
     private Boolean active;
 
     @Builder
-    @ConstructorProperties({"id", "urn", "type", "active"})
-    public ThingUpdate(String id, String urn, String type, Boolean active) {
-        this.id = id;
-        this.urn = urn;
-        this.type = type;
+    @ConstructorProperties({"active"})
+    public ThingUpdate(Boolean active) {
         this.active = active;
 
         this.version = VERSION;


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `update()` method is replaced by two new versions, so that they are consistent with lookup and deletion:
- `updateById()`
- `updateByTypeAndUrn()`

In line with this, the different identifier fields are removed from the `ThingUpdate` object.
### How is this patch documented?

Code and Javadoc.
### How was this patch tested?

Will be tested in RDAO and JPA implementation.
#### Depends On

Nothing.
