### PR TITLE
Return an empty Optional if a thing already existed

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -16,10 +16,10 @@ public interface ThingDao {
      *
      * @param tenantUrn the tenant URN
      * @param thingCreate the thing to create
-     * @return an {@link ThingResponse} instance for the created thing
+     * @return an {@link ThingResponse} instance for the created thing or {@code empty} if the thing already exists
      * @throws ConstraintViolationException if the {@link ThingCreate} violates constraints enforced by the persistence service
      */
-    ThingResponse create(String tenantUrn, ThingCreate thingCreate) throws ConstraintViolationException;
+    Optional<ThingResponse> create(String tenantUrn, ThingCreate thingCreate) throws ConstraintViolationException;
 
     /**
      * Updates a thing identified by its type and URN in the realm of a given tenant.


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `ThingDao` returns an empty `Optional` if there already is a thing with the given URN.
### How is this patch documented?

Javadoc.
### How was this patch tested?

Will be tested in RDAO and/or JPA.
#### Depends On

Nothing.
