### PR TITLE
Feature/find by urns response

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -3,6 +3,7 @@ package net.smartcosmos.dao.things;
 import net.smartcosmos.dto.things.ThingCreate;
 import net.smartcosmos.dto.things.ThingResponse;
 import net.smartcosmos.dto.things.ThingUpdate;
+import net.smartcosmos.dto.things.ThingUrnQueryResponse;
 
 import javax.validation.ConstraintViolationException;
 import java.util.Collection;
@@ -80,9 +81,9 @@ public interface ThingDao {
      *
      * @param tenantUrn the tenant URN
      * @param urns a collection of system-assigned URNs
-     * @return a List of Optional<ThingResponse>, some of which may be empty.
+     * @return a {@link ThingUrnQueryResponse} instance containing a collection of {@link ThingResponse} instances, and a collection of not found URNs.
      */
-    List<Optional<ThingResponse>> findByUrns(String tenantUrn, Collection<String> urns);
+    ThingUrnQueryResponse findByUrns(String tenantUrn, Collection<String> urns);
 
     /**
      * Return all things in the realm of a given tenant.

--- a/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
+++ b/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
@@ -10,7 +10,8 @@ import lombok.Data;
 import lombok.Setter;
 
 import java.beans.ConstructorProperties;
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -24,18 +25,25 @@ public class ThingUrnQueryResponse {
 
     @ApiModelProperty(required = true, dataType = "Collection of ThingResponse",
         value = "The collection of found things.")
-    private final Collection<ThingResponse> data;
+    private final List<ThingResponse> data;
 
     @ApiModelProperty(required = true, dataType = "Collection of String",
         value = "The collection of URNs that could not be found.")
-    private final Collection<String> notFound;
+    private final List<String> notFound;
 
     @Builder
     @ConstructorProperties({"data", "notFound"})
-    public ThingUrnQueryResponse(Collection<ThingResponse> data, Collection<String> notFound) {
+    public ThingUrnQueryResponse(List<ThingResponse> data, List<String> notFound) {
 
-        this.data = data;
-        this.notFound = notFound;
+        this.data = new ArrayList<>();
+        if (data != null) {
+            this.data.addAll(data);
+        }
+
+        this.notFound = new ArrayList<>();
+        if (notFound != null) {
+            this.notFound.addAll(notFound);
+        }
 
         this.version = VERSION;
     }

--- a/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
+++ b/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
@@ -1,0 +1,42 @@
+package net.smartcosmos.dto.things;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+
+import java.beans.ConstructorProperties;
+import java.util.Collection;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties({"version"})
+@ApiModel(description = "Response received when querying for Things by a list of URNs.")
+public class ThingUrnQueryResponse {
+
+    private static final int VERSION = 1;
+    @Setter(AccessLevel.NONE)
+    private int version = VERSION;
+
+    @ApiModelProperty(required = true, dataType = "Collection of ThingResponse",
+        value = "The collection of found things.")
+    private final Collection<ThingResponse> data;
+
+    @ApiModelProperty(required = true, dataType = "Collection of String",
+        value = "The collection of URNs that could not be found.")
+    private final Collection<String> notFound;
+
+    @Builder
+    @ConstructorProperties({"data", "notFound"})
+    public ThingUrnQueryResponse(Collection<ThingResponse> data, Collection<String> notFound) {
+
+        this.data = data;
+        this.notFound = notFound;
+
+        this.version = VERSION;
+    }
+}

--- a/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
+++ b/src/main/java/net/smartcosmos/dto/things/ThingUrnQueryResponse.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 
 import java.beans.ConstructorProperties;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Data
@@ -33,7 +34,7 @@ public class ThingUrnQueryResponse {
 
     @Builder
     @ConstructorProperties({"data", "notFound"})
-    public ThingUrnQueryResponse(List<ThingResponse> data, List<String> notFound) {
+    public ThingUrnQueryResponse(Collection<ThingResponse> data, Collection<String> notFound) {
 
         this.data = new ArrayList<>();
         if (data != null) {

--- a/src/test/java/net/smartcosmos/dto/things/ThingUrnQueryResponseTest.java
+++ b/src/test/java/net/smartcosmos/dto/things/ThingUrnQueryResponseTest.java
@@ -1,0 +1,108 @@
+package net.smartcosmos.dto.things;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ThingUrnQueryResponseTest {
+    @Test
+    public void thatVersionIsSet() {
+        ThingUrnQueryResponse entity = ThingUrnQueryResponse.builder().build();
+
+        assertNotNull(entity.getVersion());
+        assertEquals(1, entity.getVersion());
+    }
+
+    /**
+     * This actually tests if Lombok is properly used.
+     */
+    @Test(expected = NoSuchMethodException.class)
+    public void thatVersionHasNoSetter() throws Exception {
+        ThingUrnQueryResponse.class.getDeclaredMethod("setVersion", int.class);
+    }
+
+    @Test(expected = NoSuchMethodException.class)
+    public void thatDataHasNoSetter() throws Exception {
+        ThingUrnQueryResponse.class.getDeclaredMethod("setData", int.class);
+    }
+
+    @Test(expected = NoSuchMethodException.class)
+    public void thatNotFoundHasNoSetter() throws Exception {
+        ThingUrnQueryResponse.class.getDeclaredMethod("setNotFound", int.class);
+    }
+
+    @Test
+    public void thatObjectMapperIgnoresVersion() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+
+        ThingUrnQueryResponse response = ThingUrnQueryResponse.builder()
+            .data(new ArrayList<>())
+            .notFound(new ArrayList<>())
+            .build();
+
+        assertNotEquals(0, response.getVersion());
+
+        String jsonString = mapper.writeValueAsString(response);
+        JSONObject jsonObject = new JSONObject(jsonString);
+
+        assertFalse(jsonObject.has("version"));
+    }
+
+    @Test
+    public void thatBuilderEmptyWorks() {
+        ThingUrnQueryResponse response = ThingUrnQueryResponse.builder()
+            .build();
+        assertNotNull(response);
+    }
+
+    @Test
+    public void thatBuilderDataWorks() {
+        List<ThingResponse> data = new ArrayList<ThingResponse>();
+        data.add(ThingResponse.builder().build());
+
+        ThingUrnQueryResponse response = ThingUrnQueryResponse.builder()
+            .data(data)
+            .build();
+        assertNotNull(response);
+
+        assertEquals(data, response.getData());
+    }
+
+    @Test
+    public void thatBuilderNotFoundWorks() {
+        List<String> notFound = new ArrayList<String>();
+        notFound.add("urn");
+
+        ThingUrnQueryResponse response = ThingUrnQueryResponse.builder()
+            .notFound(notFound)
+            .build();
+        assertNotNull(response);
+
+        assertEquals(notFound, response.getNotFound());
+    }
+
+    @Test
+    public void testAllArgsConstructor() {
+
+        List<ThingResponse> data = new ArrayList<ThingResponse>();
+        data.add(ThingResponse.builder().build());
+
+        List<String> notFound = new ArrayList<String>();
+        notFound.add("urn");
+
+        ThingUrnQueryResponse response = new ThingUrnQueryResponse(data, notFound);
+        assertNotNull(response);
+
+        assertEquals(data, response.getData());
+        assertEquals(notFound, response.getNotFound());
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds the response model for `GET /findByUrns`:

```
{
    "data": [
        {
              "urn": "urn:thing:uuid:346e742e-2f1e-4d91-9ffe-7b38eec6219c",
              "type": "Building",
              "tenantUrn": "urn:tenant:uuid:69bb7c6a-a43b-493d-8e9d-e5a3ed65728a",
              "active": true
        },
        {
              "urn": "urn:thing:uuid:2519a8ba-fadf-4a85-a965-5a59a5b43e7d",
              "type": "Building",
              "tenantUrn": "urn:tenant:uuid:69bb7c6a-a43b-493d-8e9d-e5a3ed65728a",
              "active": true
        }
    ],
    "notFound": [
        "urn:thing:uuid:62a8d3a2-6aca-49b9-825a-147a8ee3773d"
    ]
}
```
### How is this patch documented?

Code, Javadoc.
### How was this patch tested?

Unit tests.
#### Depends On

Nothing.
