### PR TITLE
Feature/objects 828 find all

### DIFF
--- a/src/main/java/net/smartcosmos/dao/things/SortOrder.java
+++ b/src/main/java/net/smartcosmos/dao/things/SortOrder.java
@@ -1,0 +1,6 @@
+package net.smartcosmos.dao.things;
+
+public enum SortOrder {
+    ASC,
+    DESC
+}

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -273,9 +273,4 @@ public interface ThingDao {
     List<ThingResponse> delete(String tenantUrn, String type, String urn);
 
     // endregion
-
-    enum SortOrder {
-        ASC,
-        DESC
-    }
 }

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -2,6 +2,7 @@ package net.smartcosmos.dao.things;
 
 import net.smartcosmos.dto.things.ThingCreate;
 import net.smartcosmos.dto.things.ThingResponse;
+import net.smartcosmos.dto.things.ThingResponsePage;
 import net.smartcosmos.dto.things.ThingUpdate;
 
 import javax.validation.ConstraintViolationException;
@@ -64,15 +65,28 @@ public interface ThingDao {
      * @param tenantUrn the tenant URN
      * @param type the thing TYPE
      * @param urnStartsWith the first characters of the thing URN
-     * @param page the number of the results page
-     * @param size the size of a results page
      * @return all things whose {@code urn} starts with {@code urnStartsWith}
      */
     List<ThingResponse> findByTypeAndUrnStartsWith(
         String tenantUrn,
         String type,
+        String urnStartsWith);
+
+    /**
+     * Finds things of TYPE matching a specified URN start in the realm of a given tenant (paged).
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @param urnStartsWith the first characters of the thing URN
+     * @param page the number of the results page
+     * @param size the size of a results page
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    ThingResponsePage<ThingResponse> findByTypeAndUrnStartsWith(
+        String tenantUrn,
+        String type,
         String urnStartsWith,
-        Long page,
+        Integer page,
         Integer size);
 
     /**
@@ -88,11 +102,19 @@ public interface ThingDao {
      * Return all things in the realm of a given tenant.
      *
      * @param tenantUrn the tenant URN
-     * @param page the number of the results page
-     * @param size the size of a results page
      * @return the list of {@link ThingResponse} instances in the realm
      */
-    List<ThingResponse> findAll(String tenantUrn, Long page, Integer size);
+    List<ThingResponse> findAll(String tenantUrn);
+
+    /**
+     * Return all things in the realm of a given tenant (paged).
+     *
+     * @param tenantUrn the tenant URN
+     * @param page the number of the results page
+     * @param size the size of a results page
+     * @return a page of {@link ThingResponse} instances in the realm
+     */
+    ThingResponsePage<ThingResponse> findAll(String tenantUrn, Integer page, Integer size);
 
     /**
      * Deletes a thing matching a specified type and URN in the realm of a given tenant.
@@ -103,4 +125,5 @@ public interface ThingDao {
      * @return the list of deleted {@link ThingResponse} instances
      */
     List<ThingResponse> delete(String tenantUrn, String type, String urn);
+
 }

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -2,7 +2,7 @@ package net.smartcosmos.dao.things;
 
 import net.smartcosmos.dto.things.ThingCreate;
 import net.smartcosmos.dto.things.ThingResponse;
-import net.smartcosmos.dto.things.ThingResponsePage;
+import net.smartcosmos.dto.things.Page;
 import net.smartcosmos.dto.things.ThingUpdate;
 
 import javax.validation.ConstraintViolationException;
@@ -82,7 +82,7 @@ public interface ThingDao {
      * @param size the size of a results page
      * @return all things whose {@code urn} starts with {@code urnStartsWith}
      */
-    ThingResponsePage<ThingResponse> findByTypeAndUrnStartsWith(
+    Page<ThingResponse> findByTypeAndUrnStartsWith(
         String tenantUrn,
         String type,
         String urnStartsWith,
@@ -114,7 +114,7 @@ public interface ThingDao {
      * @param size the size of a results page
      * @return a page of {@link ThingResponse} instances in the realm
      */
-    ThingResponsePage<ThingResponse> findAll(String tenantUrn, Integer page, Integer size);
+    Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size);
 
     /**
      * Deletes a thing matching a specified type and URN in the realm of a given tenant.

--- a/src/main/java/net/smartcosmos/dao/things/ThingDao.java
+++ b/src/main/java/net/smartcosmos/dao/things/ThingDao.java
@@ -12,6 +12,8 @@ import java.util.Optional;
 
 public interface ThingDao {
 
+    // region Create
+
     /**
      * Creates a thing in the realm of a given tenant.
      *
@@ -21,6 +23,10 @@ public interface ThingDao {
      * @throws ConstraintViolationException if the {@link ThingCreate} violates constraints enforced by the persistence service
      */
     Optional<ThingResponse> create(String tenantUrn, ThingCreate thingCreate) throws ConstraintViolationException;
+
+    // endregion
+
+    // region Update
 
     /**
      * Updates a thing identified by its type and URN in the realm of a given tenant.
@@ -34,8 +40,38 @@ public interface ThingDao {
      */
     Optional<ThingResponse> update(String tenantUrn, String type, String urn, ThingUpdate updateThing) throws ConstraintViolationException;
 
+    // endregion
+
+    // region Find By Type
+
     /**
      * Finds things of TYPE in the realm of a given tenant.
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    List<ThingResponse> findByType(
+        String tenantUrn,
+        String type);
+
+    /**
+     * Finds things of TYPE in the realm of a given tenant (sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    List<ThingResponse> findByType(
+        String tenantUrn,
+        String type,
+        SortOrder sortOrder,
+        String sortBy);
+
+    /**
+     * Finds things of TYPE in the realm of a given tenant (paged).
      *
      * @param tenantUrn the tenant URN
      * @param type the thing TYPE
@@ -43,11 +79,34 @@ public interface ThingDao {
      * @param size the size of a results page
      * @return all things whose {@code urn} starts with {@code urnStartsWith}
      */
-    List<ThingResponse> findByType(
+    Page<ThingResponse> findByType(
         String tenantUrn,
         String type,
         Long page,
         Integer size);
+
+    /**
+     * Finds things of TYPE in the realm of a given tenant (paged and sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @param page the number of the results page
+     * @param size the size of a results page
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    Page<ThingResponse> findByType(
+        String tenantUrn,
+        String type,
+        Integer page,
+        Integer size,
+        SortOrder sortOrder,
+        String sortBy);
+
+    // endregion
+
+    // region Find By Type and URN
 
     /**
      * Finds a thing of TYPE matching a specified URN in the realm of a given tenant.
@@ -58,6 +117,10 @@ public interface ThingDao {
      * @return the {@link ThingResponse} instance for the retrieved thing or {@code empty} if the thing does not exist
      */
     Optional<ThingResponse> findByTypeAndUrn(String tenantUrn, String type, String urn);
+
+    // endregion
+
+    // region Find By Type and URN startsWith
 
     /**
      * Finds things of TYPE matching a specified URN start in the realm of a given tenant.
@@ -71,6 +134,23 @@ public interface ThingDao {
         String tenantUrn,
         String type,
         String urnStartsWith);
+
+    /**
+     * Finds things of TYPE matching a specified URN start in the realm of a given tenant (sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @param urnStartsWith the first characters of the thing URN
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    List<ThingResponse> findByTypeAndUrnStartsWith(
+        String tenantUrn,
+        String type,
+        String urnStartsWith,
+        SortOrder sortOrder,
+        String sortBy);
 
     /**
      * Finds things of TYPE matching a specified URN start in the realm of a given tenant (paged).
@@ -90,6 +170,31 @@ public interface ThingDao {
         Integer size);
 
     /**
+     * Finds things of TYPE matching a specified URN start in the realm of a given tenant (paged and sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param type the thing TYPE
+     * @param urnStartsWith the first characters of the thing URN
+     * @param page the number of the results page
+     * @param size the size of a results page
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return all things whose {@code urn} starts with {@code urnStartsWith}
+     */
+    Page<ThingResponse> findByTypeAndUrnStartsWith(
+        String tenantUrn,
+        String type,
+        String urnStartsWith,
+        Integer page,
+        Integer size,
+        SortOrder sortOrder,
+        String sortBy);
+
+    // endregion
+
+    // region Find By URNs
+
+    /**
      * Finds all things matching an input collection of URNs in the realm of a given tenant.
      *
      * @param tenantUrn the tenant URN
@@ -99,12 +204,37 @@ public interface ThingDao {
     List<ThingResponse> findByUrns(String tenantUrn, Collection<String> urns);
 
     /**
+     * Finds all things matching an input collection of URNs in the realm of a given tenant (sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param urns a collection of system-assigned URNs
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return a list containing all found {@link ThingResponse} instances.
+     */
+    List<ThingResponse> findByUrns(String tenantUrn, Collection<String> urns, SortOrder sortOrder, String sortBy);
+
+    // endregion
+
+    // region Find All
+
+    /**
      * Return all things in the realm of a given tenant.
      *
      * @param tenantUrn the tenant URN
      * @return the list of {@link ThingResponse} instances in the realm
      */
     List<ThingResponse> findAll(String tenantUrn);
+
+    /**
+     * Return all things in the realm of a given tenant (sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return the list of {@link ThingResponse} instances in the realm
+     */
+    List<ThingResponse> findAll(String tenantUrn, SortOrder sortOrder, String sortBy);
 
     /**
      * Return all things in the realm of a given tenant (paged).
@@ -117,6 +247,22 @@ public interface ThingDao {
     Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size);
 
     /**
+     * Return all things in the realm of a given tenant (paged and sorted).
+     *
+     * @param tenantUrn the tenant URN
+     * @param page the number of the results page
+     * @param size the size of a results page
+     * @param sortOrder order to sort the result, can be {@code ASC} or {@code DESC}
+     * @param sortBy name of the field to sort by
+     * @return a page of {@link ThingResponse} instances in the realm
+     */
+    Page<ThingResponse> findAll(String tenantUrn, Integer page, Integer size, SortOrder sortOrder, String sortBy);
+
+    // endregion
+
+    // region Delete
+
+    /**
      * Deletes a thing matching a specified type and URN in the realm of a given tenant.
      *
      * @param tenantUrn  the tenant URN
@@ -126,4 +272,10 @@ public interface ThingDao {
      */
     List<ThingResponse> delete(String tenantUrn, String type, String urn);
 
+    // endregion
+
+    enum SortOrder {
+        ASC,
+        DESC
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -11,7 +11,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties({"version"})
 @ApiModel(description = "Paged response received when querying for Things.")
-public class ThingResponsePage<T> {
+public class Page<T> {
 
     private final List<T> data;
     private final PageInformation page;

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -3,9 +3,12 @@ package net.smartcosmos.dto.things;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
+import lombok.Builder;
 import lombok.Data;
 
-import java.util.List;
+import java.beans.ConstructorProperties;
+import java.util.ArrayList;
+import java.util.Collection;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -13,6 +16,17 @@ import java.util.List;
 @ApiModel(description = "Paged response received when querying for Things.")
 public class Page<T> {
 
-    private final List<T> data;
+    private final Collection<T> data;
     private final PageInformation page;
+
+    @Builder
+    @ConstructorProperties({"data", "page"})
+    public Page(Collection<T> data, PageInformation page) {
+        this.data = new ArrayList<>();
+        if (data != null) {
+            this.data.addAll(data);
+        }
+
+        this.page = page;
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/things/PageInformation.java
+++ b/src/main/java/net/smartcosmos/dto/things/PageInformation.java
@@ -6,12 +6,20 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@AllArgsConstructor
 @Builder
+@AllArgsConstructor
 @ApiModel(description = "Meta information on paged responses received.")
 public class PageInformation {
-    private final Integer size;
-    private final Long totalElements;
-    private final Integer totalPages;
-    private final Integer number;
+    // primitive types because of default values
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final int number;
+
+    public PageInformation() {
+        this.size = 0;
+        this.totalElements = 0;
+        this.totalPages = 0;
+        this.number = 0;
+    }
 }

--- a/src/main/java/net/smartcosmos/dto/things/PageInformation.java
+++ b/src/main/java/net/smartcosmos/dto/things/PageInformation.java
@@ -1,0 +1,17 @@
+package net.smartcosmos.dto.things;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@ApiModel(description = "Paged response received when querying for Things.")
+@Builder
+public class PageInformation {
+    private final Integer size;
+    private final Long totalElements;
+    private final Integer totalPages;
+    private final Integer number;
+}

--- a/src/main/java/net/smartcosmos/dto/things/PageInformation.java
+++ b/src/main/java/net/smartcosmos/dto/things/PageInformation.java
@@ -7,8 +7,8 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-@ApiModel(description = "Paged response received when querying for Things.")
 @Builder
+@ApiModel(description = "Meta information on paged responses received.")
 public class PageInformation {
     private final Integer size;
     private final Long totalElements;

--- a/src/main/java/net/smartcosmos/dto/things/ThingResponsePage.java
+++ b/src/main/java/net/smartcosmos/dto/things/ThingResponsePage.java
@@ -1,0 +1,18 @@
+package net.smartcosmos.dto.things;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties({"version"})
+@ApiModel(description = "Paged response received when querying for Things.")
+public class ThingResponsePage<T> {
+
+    private final List<T> data;
+    private final PageInformation page;
+}

--- a/src/test/java/net/smartcosmos/dto/things/PageInformationTest.java
+++ b/src/test/java/net/smartcosmos/dto/things/PageInformationTest.java
@@ -1,0 +1,76 @@
+package net.smartcosmos.dto.things;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class PageInformationTest {
+
+    @Test
+    public void thatValuesAreInitializedWithBuilder() {
+        PageInformation pageInformation = PageInformation.builder().build();
+
+        assertNotNull(pageInformation);
+
+        assertNotNull(pageInformation.getNumber());
+        assertEquals(0, pageInformation.getNumber());
+
+        assertNotNull(pageInformation.getSize());
+        assertEquals(0, pageInformation.getSize());
+
+        assertNotNull(pageInformation.getTotalElements());
+        assertEquals(0, pageInformation.getTotalElements());
+
+        assertNotNull(pageInformation.getTotalPages());
+        assertEquals(0, pageInformation.getTotalPages());
+    }
+
+    @Test
+    public void thatValuesAreInitializedWithConstructor() {
+        PageInformation pageInformation = new PageInformation();
+
+        assertNotNull(pageInformation);
+
+        assertNotNull(pageInformation.getNumber());
+        assertEquals(0, pageInformation.getNumber());
+
+        assertNotNull(pageInformation.getSize());
+        assertEquals(0, pageInformation.getSize());
+
+        assertNotNull(pageInformation.getTotalElements());
+        assertEquals(0, pageInformation.getTotalElements());
+
+        assertNotNull(pageInformation.getTotalPages());
+        assertEquals(0, pageInformation.getTotalPages());
+    }
+
+    @Test
+    public void thatValuesCanBeSetWithBuilder() {
+        final int expectedSize = 10;
+        final int expectedNumber = 1;
+        final long expectedTotalElements = 123;
+        final int expectedTotalPages = 13;
+
+        PageInformation pageInformation = PageInformation.builder()
+            .number(expectedNumber)
+            .size(expectedSize)
+            .totalElements(expectedTotalElements)
+            .totalPages(expectedTotalPages)
+            .build();
+
+        assertNotNull(pageInformation);
+
+        assertNotNull(pageInformation.getNumber());
+        assertEquals(expectedNumber, pageInformation.getNumber());
+
+        assertNotNull(pageInformation.getSize());
+        assertEquals(expectedSize, pageInformation.getSize());
+
+        assertNotNull(pageInformation.getTotalElements());
+        assertEquals(expectedTotalElements, pageInformation.getTotalElements());
+
+        assertNotNull(pageInformation.getTotalPages());
+        assertEquals(expectedTotalPages, pageInformation.getTotalPages());
+    }
+}

--- a/src/test/java/net/smartcosmos/dto/things/PageTest.java
+++ b/src/test/java/net/smartcosmos/dto/things/PageTest.java
@@ -1,0 +1,80 @@
+package net.smartcosmos.dto.things;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+public class PageTest {
+
+    /*
+        The Lombok plugin in IntelliJ has some issues with generics, but Lombok itself is fine with that.
+        It just needs some assistance on the right type.
+        However, there probably will be some "compiler warnings" in the IDE, but not in the compiler itself.
+        That's what tests are for, right? :)
+
+        (see https://reinhard.codes/2015/07/14/project-lomboks-builder-annotation-and-generics/)
+     */
+
+    @Test
+    public void thatBuilderEmptyWorks() {
+        // Don't mind the IDE complaining about incompatible types - this code compiles.
+        Page<ThingResponse> page = Page.<ThingResponse>builder()
+            .build();
+        assertNotNull(page);
+    }
+
+    @Test
+    public void thatBuilderEmptyDataWorks() {
+        List<ThingResponse> data = new ArrayList<>();
+
+        Page<ThingResponse> page = Page.<ThingResponse>builder()
+            .data(data) // No worries, this works!
+            .build();
+        assertNotNull(page);
+        assertEquals(data, page.getData());
+    }
+
+    @Test
+    public void thatBuilderNullDataWorks() {
+        List<ThingResponse> data = new ArrayList<>();
+        data.add(ThingResponse.builder().build());
+
+        Page<ThingResponse> page = Page.<ThingResponse>builder()
+            .data(data) // No worries, this works!
+            .build();
+        assertNotNull(page);
+        assertNotNull(page.getData());
+        assertFalse(page.getData().isEmpty());
+        assertEquals(1, page.getData().size());
+    }
+
+    @Test
+    public void thatBuilderDataWorks() {
+        List<ThingResponse> data = null;
+
+        Page<ThingResponse> page = Page.<ThingResponse>builder()
+            .data(data) // No worries, this works!
+            .build();
+        assertNotNull(page);
+        assertNotNull(page.getData());
+        assertTrue(page.getData().isEmpty());
+    }
+
+    @Test
+    public void thatBuilderPageWorks() {
+        PageInformation pageInfo = PageInformation.builder().build();
+
+        Page<ThingResponse> page = Page.<ThingResponse>builder()
+            .page(pageInfo)
+            .build();
+        assertNotNull(page);
+        assertNotNull(page.getPage());
+        assertEquals(pageInfo, page.getPage());
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds models to provide paged responses without adding dependencies on Spring Data and declares methods for paged and unpaged responses in `ThingDao`. Methods for unpaged responses might be removed in the future.
### How is this patch documented?

Swagger annotations, Code.
### How was this patch tested?

Unit tests.
#### Depends On

Nothing.
