### PR TITLE
Bugfix/page builder

### DIFF
--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -19,7 +19,7 @@ public class Page<T> {
     private final PageInformation page;
 
     @ConstructorProperties({"data", "page"})
-    public Page(List<T> data, PageInformation page) {
+    protected Page(List<T> data, PageInformation page) {
         this.data = new ArrayList<>();
         if (data != null) {
             this.data.addAll(data);

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -3,7 +3,6 @@ package net.smartcosmos.dto.things;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
-import lombok.Builder;
 import lombok.Data;
 
 import java.beans.ConstructorProperties;
@@ -19,7 +18,6 @@ public class Page<T> {
     private final List<T> data;
     private final PageInformation page;
 
-    @Builder
     @ConstructorProperties({"data", "page"})
     public Page(List<T> data, PageInformation page) {
         this.data = new ArrayList<>();
@@ -28,5 +26,35 @@ public class Page<T> {
         }
 
         this.page = page;
+    }
+
+    public static PageBuilder builder() {
+        return new PageBuilder<>();
+    }
+
+    public static class PageBuilder<T> {
+        private List<T> data;
+        private PageInformation page;
+
+        PageBuilder() {
+        }
+
+        public Page.PageBuilder data(List<T> data) {
+            this.data = data;
+            return this;
+        }
+
+        public Page.PageBuilder page(PageInformation page) {
+            this.page = page;
+            return this;
+        }
+
+        public Page<T> build() {
+            return new Page<>(data, page);
+        }
+
+        public String toString() {
+            return "net.smartcosmos.dto.things.Page.PageBuilder(data=" + this.data + ", page=" + this.page + ")";
+        }
     }
 }

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -33,9 +33,11 @@ public class Page<T> {
         It just needs some assistance on the right type.
         However, while Travis and the local machine were able to build the project and run tests, Jenkins wasn't for
         some reason. That's why the @Builder annotation is de-lomboked for now.
-        That's what tests are for, right? :)
 
         (see https://reinhard.codes/2015/07/14/project-lomboks-builder-annotation-and-generics/)
+
+        There is also a GitHub issue for the Lombok plugin:
+        https://github.com/mplushnikov/lombok-intellij-plugin/issues/127
      */
 
     public static <T>PageBuilder<T> builder() {

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -28,6 +28,16 @@ public class Page<T> {
         this.page = page;
     }
 
+    /*
+        The Lombok plugin in IntelliJ has some issues with generics, but Lombok itself is actually fine with that.
+        It just needs some assistance on the right type.
+        However, while Travis and the local machine were able to build the project and run tests, Jenkins wasn't for
+        some reason. That's why the @Builder annotation is de-lomboked for now.
+        That's what tests are for, right? :)
+
+        (see https://reinhard.codes/2015/07/14/project-lomboks-builder-annotation-and-generics/)
+     */
+
     public static <T>PageBuilder<T> builder() {
         return new PageBuilder<>();
     }

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -28,7 +28,7 @@ public class Page<T> {
         this.page = page;
     }
 
-    public static PageBuilder builder() {
+    public static <T>PageBuilder<T> builder() {
         return new PageBuilder<>();
     }
 
@@ -39,12 +39,12 @@ public class Page<T> {
         PageBuilder() {
         }
 
-        public Page.PageBuilder data(List<T> data) {
+        public Page.PageBuilder<T> data(List<T> data) {
             this.data = data;
             return this;
         }
 
-        public Page.PageBuilder page(PageInformation page) {
+        public Page.PageBuilder<T> page(PageInformation page) {
             this.page = page;
             return this;
         }

--- a/src/test/java/net/smartcosmos/dto/things/PageTest.java
+++ b/src/test/java/net/smartcosmos/dto/things/PageTest.java
@@ -1,29 +1,19 @@
 package net.smartcosmos.dto.things;
 
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
-
 public class PageTest {
-
-    /*
-        The Lombok plugin in IntelliJ has some issues with generics, but Lombok itself is fine with that.
-        It just needs some assistance on the right type.
-        However, there probably will be some "compiler warnings" in the IDE, but not in the compiler itself.
-        That's what tests are for, right? :)
-
-        (see https://reinhard.codes/2015/07/14/project-lomboks-builder-annotation-and-generics/)
-     */
 
     @Test
     public void thatBuilderEmptyWorks() {
-        // Don't mind the IDE complaining about incompatible types - this code compiles.
         Page<ThingResponse> page = Page.<ThingResponse>builder()
             .build();
         assertNotNull(page);
@@ -34,7 +24,7 @@ public class PageTest {
         List<ThingResponse> data = new ArrayList<>();
 
         Page<ThingResponse> page = Page.<ThingResponse>builder()
-            .data(data) // No worries, this works!
+            .data(data)
             .build();
         assertNotNull(page);
         assertEquals(data, page.getData());
@@ -46,7 +36,7 @@ public class PageTest {
         data.add(ThingResponse.builder().build());
 
         Page<ThingResponse> page = Page.<ThingResponse>builder()
-            .data(data) // No worries, this works!
+            .data(data)
             .build();
         assertNotNull(page);
         assertNotNull(page.getData());
@@ -59,8 +49,21 @@ public class PageTest {
         List<ThingResponse> data = null;
 
         Page<ThingResponse> page = Page.<ThingResponse>builder()
-            .data(data) // No worries, this works!
+            .data(data)
             .build();
+        assertNotNull(page);
+        assertNotNull(page.getData());
+        assertTrue(page.getData().isEmpty());
+    }
+
+    @Test
+    public void thatBuilderDataWorksWithoutType() {
+        List data = new ArrayList();
+
+        Page page = Page.builder()
+            .data(data)
+            .build();
+
         assertNotNull(page);
         assertNotNull(page.getData());
         assertTrue(page.getData().isEmpty());


### PR DESCRIPTION
### What changes were proposed in this pull request?

For some reason, the `@Builder` annotation didn't always work with generics, and IntelliJ kept showing compiler warnings, although the code actually compiled.

This wasn't the problem, but the tests didn't succeed:

```
Tests in error: 
  PageTest.thatBuilderDataWorks:62 NoSuchMethod net.smartcosmos.dto.things.Page$...
  PageTest.thatBuilderEmptyDataWorks:37 NoSuchMethod net.smartcosmos.dto.things....
  PageTest.thatBuilderNullDataWorks:49 NoSuchMethod net.smartcosmos.dto.things.P...
```

Tests were fine in IntelliJ, on the command line, with Travis, but Jenkins kept having test errors. So I de-lomboked the builder and made sure everything looks nice, i.e. fixed the builder's generic typing manually.
### How is this patch documented?

Comment in the `Page` class.
### How was this patch tested?

Unit tests.
#### Depends On

Nothing.
