### PR TITLE
Prevent null page information

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS DAO Things Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+No new features are added in this release.
+
+=== Bugfixes & Improvements
+
+* OBJECTS-979 Empty page response may have missing meta information on paging
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/src/main/java/net/smartcosmos/dto/things/Page.java
+++ b/src/main/java/net/smartcosmos/dto/things/Page.java
@@ -26,7 +26,11 @@ public class Page<T> {
             this.data.addAll(data);
         }
 
-        this.page = page;
+        if (page != null) {
+            this.page = page;
+        } else {
+            this.page = new PageInformation();
+        }
     }
 
     /*

--- a/src/test/java/net/smartcosmos/dto/things/PageTest.java
+++ b/src/test/java/net/smartcosmos/dto/things/PageTest.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.dto.things;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.*;
@@ -89,5 +90,22 @@ public class PageTest {
         assertNotNull(page);
         assertNotNull(page.getPage());
         assertEquals(pageInfo, page.getPage());
+    }
+
+    @Test
+    public void thatBuilderPageHasDefaultValues() {
+
+        Page<ThingResponse> page = Page.<ThingResponse>builder().build();
+
+        assertNotNull(page.getData());
+        Collection<ThingResponse> data = page.getData();
+        assertTrue(data.isEmpty());
+
+        assertNotNull(page.getPage());
+        PageInformation pageInformation = page.getPage();
+        assertEquals(0, pageInformation.getNumber());
+        assertEquals(0, pageInformation.getSize());
+        assertEquals(0, pageInformation.getTotalPages());
+        assertEquals(0, pageInformation.getTotalElements());
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the builder for `Page`, so that `PageInformation` is not `null`.
### How is this patch documented?

Code.
### How was this patch tested?

Unit test.
#### Depends On

Nothing.
